### PR TITLE
Update Docker image reference

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "druhnoj/quickstart:latest",
+  "image": "zenmldocker/quickstart:latest",
   "customizations": {
     // Configure properties specific to VS Code.
     "vscode": {


### PR DESCRIPTION
Use one within the `zenmldocker` account instead of one from the contributor.